### PR TITLE
Update minijasminenode to ~1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/testdouble/grunt-jasmine-bundle.git"
   },
   "dependencies": {
-    "minijasminenode": "~0.2.4",
+    "minijasminenode": "~1.1.1",
     "jasmine-given": "~2.5.0",
     "jasmine-only": "~0.1.0",
     "jasmine-before-all": "~0.1.0",


### PR DESCRIPTION
Version 0.2.4 of minijasminenode uses deprecated `util.print`. 
Using latest nodeJS (0.12.5), it echoes a lot of `util.print: Use console.log instead`. This patch updates minijasminenode to 1.1.1 which fix this issue.