### PR TITLE
Use >= for grunt peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coffee-script": "~1.6.3"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.1"
   },
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
I've tested this repo with grunt@1.0.1 and it works fine but having such a stringent peer requirement means that `npm shrinkwrap` blows up. Even though `npm install` now simply warns that the peer is invalid, `npm shrinkwrap` still requires all peers to be valid or it throws an error.
